### PR TITLE
Set requirement for Kodi 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # plugin.video.9anime - 9Anime plugin for kodi
 
 Kodi Plugin that let's you watch almost all animes HD and for free.
+**This Plugin Requires Kodi Version 17.0+**
 
 <img width="32%" src="https://cloud.githubusercontent.com/assets/1080411/24332362/d9f784b6-124d-11e7-9ffe-db16b4a01609.png"> <img width="32%" src="https://cloud.githubusercontent.com/assets/1080411/24332363/dc0cc630-124d-11e7-9a5a-fdb2447f49aa.png"> <img width="32%" src="https://cloud.githubusercontent.com/assets/1080411/24332366/dd68b5fc-124d-11e7-9abb-70297510c49f.png">
 <img width="32%" src="https://cloud.githubusercontent.com/assets/1080411/24332368/e2c32f32-124d-11e7-83e7-8e60fab381c0.png"> <img width="32%" src="https://cloud.githubusercontent.com/assets/1080411/24332369/e4fc41ee-124d-11e7-86b0-6749b19f2b7c.png"> <img width="32%" src="https://cloud.githubusercontent.com/assets/1080411/24332370/e7405526-124d-11e7-9e9c-523312e52cb2.png">

--- a/addon.xml
+++ b/addon.xml
@@ -4,7 +4,7 @@
        version="0.0.2"
        provider-name="Hagai Cohen">
   <requires>
-    <import addon="xbmc.python" version="2.1.0"/>
+    <import addon="xbmc.gui" version="5.12.0"/>
     <import addon="script.module.requests" version="2.12.4"/>
     <import addon="script.common.plugin.cache" version="2.5.5"/>
   </requires>


### PR DESCRIPTION
Based on http://kodi.wiki/view/addon.xml replace <import addon=xmbc.python with <import addon=xmbc.gui for 5.12.0 so we require at least kodi 17 because if the required ssl for python